### PR TITLE
Handle DEBUG loader invocation and add tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 import regeneratorRuntime from "regenerator-runtime";
 
-const DEBUG = process.env.DEBUG === true;
+const envDebug =
+  typeof process !== "undefined" && process.env ? process.env.DEBUG : undefined;
+
+const DEBUG =
+  typeof envDebug === "string"
+    ? envDebug.toLowerCase() === "true"
+    : Boolean(envDebug);
 
 const debugPrint = (...toPrint) => {
   return DEBUG ? console.log(toPrint) : null;
@@ -101,7 +107,9 @@ const createGntc = (props) => {
   };
 
   const iteration = (i) => {
-    if (DEBUG && i % 100 === 0) loader(i);
+    if (DEBUG && typeof loader === "function" && i % 100 === 0) {
+      loader(i);
+    }
 
     population.forEach(solution => {
       solution.score = fitness(solution.choice, seed);


### PR DESCRIPTION
## Summary
- normalize the DEBUG flag to handle string environment values and guard loader usage
- update generator specs to consume the returned best result and cover DEBUG loader behavior
- add coverage to ensure debug loader hooks only run when configured

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da95fb8c1c8328aabd0be38d492467